### PR TITLE
Set the primary property on the hamburger menu

### DIFF
--- a/data/resources/ui/help-overlay.ui
+++ b/data/resources/ui/help-overlay.ui
@@ -18,6 +18,12 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
+                <property name="accelerator">F10</property>
+                <property name="title" translatable="yes" context="shortcut window">Open application menu</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes" context="shortcut window">Quit</property>
                 <property name="action-name">app.quit</property>
               </object>

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -22,6 +22,7 @@
                       <object class="GtkMenuButton">
                         <property name="icon-name">open-menu-symbolic</property>
                         <property name="menu-model">primary_menu</property>
+                        <property name="primary">True</property>
                       </object>
                     </child>
                   </object>
@@ -62,6 +63,7 @@
                       <object class="GtkMenuButton">
                         <property name="icon-name">open-menu-symbolic</property>
                         <property name="menu-model">primary_menu</property>
+                        <property name="primary">True</property>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
Allows keyboard users to open the menu with the F10 key, as per GNOME human interface guidelines.