### PR TITLE
Add a couple of missing dependencies to meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,9 @@ base_id = 'com.saivert.pwvucontrol'
 dependency('glib-2.0', version: '>= 2.66')
 dependency('gio-2.0', version: '>= 2.66')
 dependency('gtk4', version: '>= 4.0.0')
+dependency('libadwaita-1', version: '>= 1.5.0')
+dependency('libpipewire-0.3', version: '>= 1.0.5')
+dependency('wireplumber-0.4', version: '>= 0.4.15')
 
 find_program('glib-compile-resources', required: true)
 glib_compile_schemas = find_program('glib-compile-schemas', required: true)


### PR DESCRIPTION
I'm not very familiar with this build environment (rust + meson), is this the right thing to do? These missing dependencies showed up at compile time, but `setup` was happy, so I thought I'd add these here.

Thanks!