### PR TITLE
Make LevelBarProvidersPassive

### DIFF
--- a/src/backend/manager.rs
+++ b/src/backend/manager.rs
@@ -149,7 +149,7 @@ mod imp {
                 if let Some(node) = object.downcast_ref::<wp::pw::Node>() {
                     let mut hidden: bool = false;
                     // Hide ourselves.
-                    if node.name().unwrap_or_default() == "pwvucontrol-peak-detect" {
+                    if node.name().unwrap_or_default() == "PulseAudio Volume Control" {
                         hidden = true;
                     }
 

--- a/src/ui/levelprovider.rs
+++ b/src/ui/levelprovider.rs
@@ -45,6 +45,7 @@ impl LevelbarProvider {
             "node.rate" => "1/25",
             "node.latency" => "1/25",
             "node.name" => "PulseAudio Volume Control",
+            "node.passive" => "true",
             "media.name" => "Peak detect",
             "resample.peaks" => "true",
             "stream.monitor" => "true",


### PR DESCRIPTION
When nodes are set to passive they stop preventing connected nodes from becoming inactive. for example this is required for bluetooth speakers to allow switching away from passive outputs.

Also set name of nodes that will be filtered by program to "PulseAudio Volume Control", since in 896a2793 node.name was changed to that for compatibility purposes.