### PR TITLE
Replace emblem-default icon with radio-checked

### DIFF
--- a/data/resources/ui/sinkbox.blp
+++ b/data/resources/ui/sinkbox.blp
@@ -24,7 +24,7 @@ template $PwSinkBox: ListBoxRow {
           "expander-row-arrow",
         ]
 
-        icon-name: "emblem-default-symbolic";
+        icon-name: "radio-checked-symbolic";
       }
     }
   }


### PR DESCRIPTION
emblem-default-symbolic is [no longer in the Adwaita icon theme][1] so the "Set default" icon appears broken in up-to-date desktop environments.

Closes #108

[1]: https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/merge_requests/78