### PR TITLE
Filter unknown routes by direction

### DIFF
--- a/src/backend/pwroutefiltermodel.rs
+++ b/src/backend/pwroutefiltermodel.rs
@@ -66,7 +66,9 @@ mod imp {
                         .skip(position as usize)
                         .map_while(Result::ok)
                         .enumerate() {
-                        if routeobject.direction() == widget.direction() && routeobject.availability() == ParamAvailability::Yes || routeobject.availability() == ParamAvailability::Unknown {
+                        if routeobject.direction() == widget.direction()
+                            && matches!(routeobject.availability(), ParamAvailability::Yes | ParamAvailability::Unknown)
+                        {
                             hashset.insert(a as u32);
                         }
                     }
@@ -95,5 +97,27 @@ glib::wrapper! {
 impl PwRouteFilterModel {
     pub(crate) fn new(direction: RouteDirection, model: Option<&impl IsA<gio::ListModel>>) -> Self {
         glib::Object::builder().property("model", model).property("direction", direction).build()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filters_unknown_routes_by_direction() {
+        let routes = gio::ListStore::new::<PwRouteObject>();
+        routes.append(&PwRouteObject::new(0, "Internal microphone", ParamAvailability::Unknown, RouteDirection::Input, &[]));
+        routes.append(&PwRouteObject::new(3, "Speakers", ParamAvailability::Unknown, RouteDirection::Output, &[]));
+        routes.append(&PwRouteObject::new(4, "Headphones", ParamAvailability::No, RouteDirection::Output, &[]));
+
+        for (direction, expected_index) in [(RouteDirection::Input, 0), (RouteDirection::Output, 3)] {
+            let filtered = PwRouteFilterModel::new(direction, Some(&routes));
+
+            assert_eq!(filtered.n_items(), 1);
+            let route = filtered.item(0).and_downcast::<PwRouteObject>().expect("filtered route");
+            assert_eq!(route.index(), expected_index);
+            assert_eq!(route.direction(), direction);
+        }
     }
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -51,3 +51,11 @@ custom_target(
     '@OUTPUT@',
   ],
 )
+
+test(
+  'cargo-test',
+  cargo,
+  args: ['test'] + cargo_options,
+  env: cargo_env,
+  timeout: 300,
+)


### PR DESCRIPTION
## Summary

- require route direction to match for both available and unknown routes
- add a headless model regression test for input/output routes with unknown availability
- register the Rust unit test with Meson

## Background

Commit f79e41e added routes whose availability is unknown, but the ungrouped
boolean expression lets every unknown route bypass the direction check. This
can show an input route in an output device's Port menu, or vice versa.

On an ALSA card with both routes reported as unknown, this appeared as
`Internal microphone (0)` alongside `Speakers (3)` in the output dropdown.
The proposed expression in #34 had the intended grouping.

## Testing

- `meson compile -C build`
- `meson test -C build --print-errorlogs` (5/5 passed, including the new Rust test)
