### PR TITLE
Hide port selector for sinks without routes

### DIFF
--- a/data/resources/ui/sinkbox.blp
+++ b/data/resources/ui/sinkbox.blp
@@ -7,11 +7,16 @@ template $PwSinkBox: ListBoxRow {
       orientation: horizontal;
       spacing: 6;
 
-      Label onlabel {
-        label: _("Port:");
-      }
+      Box route_controls {
+        visible: false;
+        spacing: 6;
 
-      $PwRouteDropDown route_dropdown {}
+        Label onlabel {
+          label: _("Port:");
+        }
+
+        $PwRouteDropDown route_dropdown {}
+      }
 
       ToggleButton default_sink_toggle {
         hexpand: false;

--- a/src/meson.build
+++ b/src/meson.build
@@ -51,3 +51,11 @@ custom_target(
     '@OUTPUT@',
   ],
 )
+
+test(
+  'cargo-test',
+  cargo,
+  args: ['test'] + cargo_options,
+  env: cargo_env,
+  timeout: 300,
+)

--- a/src/ui/route_dropdown.rs
+++ b/src/ui/route_dropdown.rs
@@ -12,6 +12,10 @@ use std::cell::{Cell, RefCell};
 use wireplumber as wp;
 use wp::pw::ProxyExt;
 
+fn route_control_should_be_visible(model: Option<&gtk::gio::ListModel>) -> bool {
+    model.is_some_and(|model| model.n_items() > 0)
+}
+
 mod imp {
     use super::*;
 
@@ -51,9 +55,14 @@ mod imp {
             }
         }
 
+        fn update_visibility(&self) {
+            self.obj()
+                .set_visible(route_control_should_be_visible(self.route_dropdown.model().as_ref()));
+        }
+
         fn get_route_index(&self) -> Option<u32> {
             let nodeobject = self.nodeobject.borrow();
-            let nodeobject = nodeobject.as_ref().unwrap();
+            let nodeobject = nodeobject.as_ref()?;
 
             let Some(deviceobject) = nodeobject.device() else {
                 return None;
@@ -67,9 +76,9 @@ mod imp {
 
         fn get_route_model(&self) -> Option<PwRouteFilterModel> {
             let nodeobject = self.nodeobject.borrow();
-            let nodeobject = nodeobject.as_ref().unwrap();
+            let nodeobject = nodeobject.as_ref()?;
 
-            let deviceobject = nodeobject.device().expect("device");
+            let deviceobject = nodeobject.device()?;
             match nodeobject.nodetype() {
                 NodeType::Source => Some(deviceobject.routemodel_input()),
                 NodeType::Sink => Some(deviceobject.routemodel_output()),
@@ -78,18 +87,32 @@ mod imp {
         }
 
         pub fn set_nodeobject(&self, new_nodeobject: Option<&PwNodeObject>) {
+            self.block_signal.set(true);
             self.nodeobject.replace(new_nodeobject.cloned());
+            self.route_dropdown.set_model(gtk::gio::ListModel::NONE);
+            self.update_visibility();
 
             if let Some(nodeobject) = new_nodeobject {
-                let deviceobject = nodeobject.device().expect("nodeobject with associated device on PwRouteDropDown");
+                let Some(deviceobject) = nodeobject.device() else {
+                    self.block_signal.set(false);
+                    return;
+                };
+                let Some(route_model) = self.get_route_model() else {
+                    self.block_signal.set(false);
+                    return;
+                };
 
-                self.block_signal.set(true);
                 pwvucontrol_info!("self.route_dropdown.set_model({});", deviceobject.wpdevice().bound_id());
-                self.route_dropdown.set_model(self.get_route_model().as_ref());
+                self.route_dropdown.set_model(Some(&route_model));
+                self.update_visibility();
                 if let Some(index) = self.get_route_index() {
                     pwvucontrol_info!("self.route_dropdown.set_selected({index});");
                     self.route_dropdown.set_selected(index);
                 }
+
+                route_model.connect_items_changed(clone!(#[weak(rename_to = widget)] self, move |_, _, _, _| {
+                    widget.update_visibility();
+                }));
 
                 self.block_signal.set(false);
 
@@ -117,7 +140,7 @@ mod imp {
 
                 deviceobject.connect_route_index_output_notify(clone!(#[weak(rename_to = widget)] self, move |_| widget.update_selected()));
             } else {
-                self.route_dropdown.set_model(gtk::gio::ListModel::NONE);
+                self.block_signal.set(false);
             }
         }
     }
@@ -220,5 +243,24 @@ impl PwRouteDropDown {
 impl Default for PwRouteDropDown {
     fn default() -> Self {
         glib::Object::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn visibility_follows_route_model_contents() {
+        let routes = gtk::gio::ListStore::new::<glib::BoxedAnyObject>();
+
+        assert!(!route_control_should_be_visible(None));
+        assert!(!route_control_should_be_visible(Some(routes.upcast_ref())));
+
+        routes.append(&glib::BoxedAnyObject::new(()));
+        assert!(route_control_should_be_visible(Some(routes.upcast_ref())));
+
+        routes.remove(0);
+        assert!(!route_control_should_be_visible(Some(routes.upcast_ref())));
     }
 }

--- a/src/ui/sinkbox.rs
+++ b/src/ui/sinkbox.rs
@@ -33,6 +33,9 @@ mod imp {
         pub default_sink_toggle: TemplateChild<gtk::ToggleButton>,
 
         #[template_child]
+        pub route_controls: TemplateChild<gtk::Box>,
+
+        #[template_child]
         pub route_dropdown: TemplateChild<PwRouteDropDown>,
     }
 
@@ -75,7 +78,12 @@ mod imp {
             defaultnodesapi.connect_closure("changed", false, defaultnodesapi_closure);
             self.default_node_changed();
 
-            // Only set nodeobject once it has a device associated.
+            self.route_dropdown.set_nodeobject(Some(&item));
+            self.route_dropdown.connect_visible_notify(clone!(#[weak(rename_to = widget)] self, move |dropdown| {
+                widget.route_controls.set_visible(dropdown.is_visible());
+            }));
+            self.route_controls.set_visible(self.route_dropdown.is_visible());
+
             if let Some(node) = obj.node_object() {
                 node.connect_device_notify(clone!(#[weak(rename_to = widget)] self, move |nodeobject| {
                     widget.route_dropdown.set_nodeobject(Some(nodeobject));


### PR DESCRIPTION
## Summary

- hide the complete `Port:` control when an audio node has no associated
  PipeWire device or its direction-specific route model is empty
- update visibility when routes appear or disappear at runtime
- make route lookup tolerate device-less network and virtual sinks instead of
  reaching `expect`/`unwrap`
- add a headless regression test for the empty/non-empty model behavior

This keeps the selector unchanged for ALSA devices with real routes while
avoiding an empty `Port:` row for standalone network sinks.

## Testing

- `meson compile -C build-hide-empty-route-control`
- `meson test -C build-hide-empty-route-control --print-errorlogs` (5/5 passed)
